### PR TITLE
Limit to 1 GATT command per Device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint $(find ./src/ -name "*.py" | xargs)
+        pylint ./src
   Unittest:
     runs-on: windows-latest
     strategy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pybgapi==1.3.0
 PyQt6==6.6.1
+PyQt6-Qt6==6.6.1
 pyserial==3.5

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,7 +4,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../src"))
 
 import unittest
 
-from device import Characteristic, Service, Device
+from device import Characteristic, CharacteristicState, Service, ServiceState, Device
 
 class TestCharacteristic(unittest.TestCase):
     def test_create(self):
@@ -13,6 +13,7 @@ class TestCharacteristic(unittest.TestCase):
         self.assertEqual(characteristic.uuid, "ABCD")
         self.assertEqual(characteristic.handle, 1)
         self.assertEqual(characteristic.properties, 2)
+        self.assertEqual(characteristic.state, CharacteristicState.NONE)
 
 class TestService(unittest.TestCase):
     def test_create(self):
@@ -103,6 +104,22 @@ class TestDevice(unittest.TestCase):
 
         self.assertEqual(device.get_characteristic_by_handle(2), characterstic)
         self.assertIsNone(device.get_characteristic_by_handle(3))
+
+    def test_is_using_gatt_command(self):
+        device = Device("00:11:22:33:44:55")
+        service = Service("ABCD", 1)
+        characterstic = Characteristic("1234", 2, 2)
+
+        device.services.append(service)
+        service.characteristics.append(characterstic)
+
+        self.assertTrue(device.is_using_gatt_command())
+
+        service.state = ServiceState.DISCOVERED
+        self.assertFalse(device.is_using_gatt_command())
+
+        characterstic.state = CharacteristicState.WRITING
+        self.assertTrue(device.is_using_gatt_command())
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/run_workflows_manually.bat
+++ b/tools/run_workflows_manually.bat
@@ -1,0 +1,5 @@
+python3.12 -m coverage run %~dp0/../tools/run_all_tests.py
+python3.12 -m coverage report
+python3.12 -m coverage html
+python3.12 -m pylint %~dp0/../src
+python3.12 -m mypy %~dp0/../src --ignore-missing-imports --strict


### PR DESCRIPTION
- Limits each device to 1 GATT command (discovering, reading, writing, and subscribing) at a time.
- Adds the characteristic's state to the GUI buttons (i.e. "R" vs "R...")
- Adds a script to manually run the workflows on windows (coverage, pylint, mypy)
- Updates workflows to properly run on windows-latest (Installing PyQt6 and pylint's directory path)